### PR TITLE
<fix> Use SED_USE_EREGEXP when bumping version in tag_release

### DIFF
--- a/tag_release
+++ b/tag_release
@@ -13,7 +13,7 @@ CURRENT_VERSION=$(sed $SED_USE_EREGEXP -n 's/^(VERSION = )(.*)/\2/p' Makefile)
 git tag rel-${CURRENT_VERSION} && git push origin rel-${CURRENT_VERSION}
 
 # bump version
-sed -ri 's/^(VERSION = .*\.)([0-9]+)/echo \1$((\2+1))/ge' Makefile
+sed $SED_USE_EREGEXP -i 's/^(VERSION = .*\.)([0-9]+)/echo \1$((\2+1))/ge' Makefile
 NEW_VERSION=$(sed $SED_USE_EREGEXP -n 's/^(VERSION = )(.*)/\2/p' Makefile)
 git add Makefile
 git commit -q -m "bump version -> ${NEW_VERSION}"


### PR DESCRIPTION
I missed a spot where this needs to be fixed up to work on OS X.
